### PR TITLE
Basic skeleton for sql parsers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module parth/sqlparser
+
+go 1.22.4

--- a/hello.go
+++ b/hello.go
@@ -1,0 +1,9 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello world!")
+}
+
+//https://github.com/thedevsaddam/gojsonq?tab=readme-ov-file

--- a/parser/parseInput.go
+++ b/parser/parseInput.go
@@ -1,0 +1,55 @@
+package parser
+
+// takes in raw input from the user. then sends to sub functions to
+// parse WHERE, SELECT, LIMIT, etc.
+
+func parseInput(rawInput string) {
+
+	// {rawWhere, rawSelect, rawFrom, rawLimit} = parseArgs(rawInput)
+
+	// whereExp = parseWhere(rawWhere)
+	// parseSelect(rawSelect)
+
+}
+
+// returns rawSelect, rawFrom, rawWhere, rawLimit
+
+func parseArgs(rawInput string) {
+
+	//
+
+}
+
+// takes in raw where string. returns a predicate of some kind, that can be plugged into
+// the function that actually iterates over the array and runs the test
+func parseWhere(rawWhere string) {
+
+}
+
+// given the raw select string returns a list of columns that need to be returned
+// (ensure it could be ["*"])
+func parseSelect(rawSelect string) []string {
+
+}
+
+func findMatching(whereExp string, table []string) {
+	for index, jsonElem := range table {
+
+	}
+}
+
+// first step is WHERE function. WHERE query parser
+
+// 1. parseInput(inputString)
+// 2. whereParser creates a boolean expression. this might be recursive.
+// 3. filter method runs filter on each json element, using the query array. it outputs to
+// matchArr. MatchArr basically is passed to
+// 4. selectCols (matchArr, cols) which returns only the information in the columns.
+// cols is likely going to be a string[], served by selectParser
+// if cols is "*" returns the whole {object}[] array. if not it will
+// add only the key-value pairs in cols. for each over matchArr (this might be a for loop limited by LIMIT) and then a
+// nested loop within that's like cols.foreach add jsonElem[key] to the return. need to think about
+// what to do - need to figure out if this gets added
+//
+// and then return that
+//5. might add something to selectCols so that it picks from a table

--- a/parser/parseInput.go
+++ b/parser/parseInput.go
@@ -5,7 +5,7 @@ package parser
 
 func parseInput(rawInput string) {
 
-	// {rawWhere, rawSelect, rawFrom, rawLimit} = parseArgs(rawInput)
+	// {rawWhere, rawSelect, from, limit} = parseArgs(rawInput)
 
 	// whereExp = parseWhere(rawWhere)
 	// parseSelect(rawSelect)
@@ -32,10 +32,20 @@ func parseSelect(rawSelect string) []string {
 
 }
 
-func findMatching(whereExp string, table []string) {
-	for index, jsonElem := range table {
+// given an input predicate expression, perhaps defined recursively somewhere
+// else, and the data table, return matchArr to show all rows in the database
+// that match the requirements of where(). this will be processed by
+// selectCols
 
-	}
+func findMatching(whereExp string, table []string) []string {
+	// for index, jsonElem := range table {
+
+	// }
+}
+
+// given the number of cols to return and the number of rows to return
+func returnSelected(matchArr []string, selectedCols []string, limit int) []string {
+
 }
 
 // first step is WHERE function. WHERE query parser

--- a/parser/parseWhere.go
+++ b/parser/parseWhere.go
@@ -1,0 +1,1 @@
+package parser

--- a/sqlparse.go
+++ b/sqlparse.go
@@ -1,0 +1,3 @@
+package main
+
+// accepts the input commands. calls parseInput


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 0dc53959889db59ad23e8e20ec27aa9ec82cbdbd  | 
|--------|--------|

### Summary:
Set up the basic skeleton for an SQL parser in Go with initial structure and placeholder functions.

**Key points**:
- Added `go.mod` to define the Go module `parth/sqlparser`.
- Created `hello.go` with a basic `main` function printing "Hello world!".
- Added `parser/parseInput.go` with skeleton functions: `parseInput`, `parseArgs`, `parseWhere`, `parseSelect`, `findMatching`, and `returnSelected`.
- Added empty `parser/parseWhere.go`.
- Added `sqlparse.go` as a placeholder for the main entry point, calling `parseInput`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->